### PR TITLE
[ORD-1948] Add queue metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A lib for rabbit and sqs queues
 
-# Rabbit
+## Rabbit
 
 Requires `amqplib` to be installed separately. If you only need RabbitMQ support you can avoid also needing to install `@aws-sdk` packages by importing from `"@loke/queue-kit/rabbit"`.
 
@@ -141,4 +141,13 @@ async function main() {
     foo: "bar",
   });
 }
+```
+
+## Metrics
+
+```ts
+import { register } from "prom-client";
+import { registerMetrics } from "@loke/queue-kit"; // or "@loke/queue-kit/rabbit" or "@loke/queue-kit/sqs"
+
+registerMetrics(register);
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { RabbitData, RabbitHelper } from "./rabbit";
 export { SQSData, SQSHelper } from "./sqs";
 export { Logger, MessageHandler, AbortSignal } from "./common";
+export { registerMetrics } from "./metrics";

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,0 +1,29 @@
+import { Counter, Histogram, Registry } from "prom-client";
+
+export const messagesReceivedCounter = new Counter({
+  name: "queue_messages_received_total",
+  help: "Total number of messages received from the queue",
+  labelNames: ["queue", "provider"],
+});
+export const messagesFailedCounter = new Counter({
+  name: "queue_messages_failed_total",
+  help: "Total number of messages failed to handle",
+  labelNames: ["queue", "provider"],
+});
+export const messagesQueuedCounter = new Counter({
+  name: "queue_messages_queued_total",
+  help: "Total number of messages published to the queue",
+  labelNames: ["queue", "provider"],
+});
+export const messageHandlerDuration = new Histogram({
+  name: "queue_message_handler_duration_ms",
+  help: "Queue message handler processing time in milliseconds.",
+  labelNames: ["queue", "provider"],
+});
+
+export function registerMetrics(registry: Pick<Registry, "registerMetric">) {
+  registry.registerMetric(messagesReceivedCounter);
+  registry.registerMetric(messagesFailedCounter);
+  registry.registerMetric(messagesQueuedCounter);
+  registry.registerMetric(messageHandlerDuration);
+}

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,23 +1,24 @@
 import { Counter, Histogram, Registry } from "prom-client";
 
 export const messagesReceivedCounter = new Counter({
-  name: "queue_messages_received_total",
+  name: "queue_handler_messages_total",
   help: "Total number of messages received from the queue",
   labelNames: ["queue", "provider"],
 });
 export const messagesFailedCounter = new Counter({
-  name: "queue_messages_failed_total",
+  name: "queue_handler_failures_total",
   help: "Total number of messages failed to handle",
   labelNames: ["queue", "provider"],
 });
+export const messageHandlerDuration = new Histogram({
+  name: "queue_handler_duration_seconds",
+  help: "Queue message handler processing time in seconds.",
+  labelNames: ["queue", "provider"],
+});
+
 export const messagesQueuedCounter = new Counter({
   name: "queue_messages_queued_total",
   help: "Total number of messages published to the queue",
-  labelNames: ["queue", "provider"],
-});
-export const messageHandlerDuration = new Histogram({
-  name: "queue_message_handler_duration_ms",
-  help: "Queue message handler processing time in milliseconds.",
   labelNames: ["queue", "provider"],
 });
 


### PR DESCRIPTION
We had prom-client installed, but it wasn't used for anything.

Add some metrics to see queue activity.

queue_messages_received_total
queue_messages_failed_total
queue_messages_queued_total
queue_message_handler_duration_ms
