### PR TITLE
Update Version of AMQPlib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@aws-sdk/client-sqs": "^3.637.0",
-        "@types/amqplib": "^0.10.5",
+        "@types/amqplib": "0.10.6",
         "@types/node": "^20.16.3",
         "@typescript-eslint/eslint-plugin": "^5.19.0",
         "@typescript-eslint/parser": "^5.19.0",
@@ -1857,10 +1857,11 @@
       "dev": true
     },
     "node_modules/@types/amqplib": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.10.5.tgz",
-      "integrity": "sha512-/cSykxROY7BWwDoi4Y4/jLAuZTshZxd8Ey1QYa/VaXriMotBDoou7V/twJiOSHzU6t1Kp1AHAUXGCgqq+6DNeg==",
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.10.6.tgz",
+      "integrity": "sha512-vQLVypBS1JQcfTXhl1Td1EEeLdtb+vuulOb4TrzYiLyP2aYLMAEzB3pNmEA0jBm0xIXu946Y7Xwl19Eidl32SQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "devDependencies": {
     "@aws-sdk/client-sqs": "^3.637.0",
-    "@types/amqplib": "^0.10.5",
+    "@types/amqplib": "0.10.6",
     "@types/node": "^20.16.3",
     "@typescript-eslint/eslint-plugin": "^5.19.0",
     "@typescript-eslint/parser": "^5.19.0",


### PR DESCRIPTION
Internal change only

## Summary

After manually attempting to integrate this library into a new system (`loke-manager`), it was found that a patch version of `@types/amqplib` would break a lot of the types used throughout the package. The problematic version was `v0.10.7`, so this update removes the `^` from the version (preventing accidental version bumps if a future PR adjusts functionality) and updates to `v0.10.6` which was found to be the latest version able to be used without breaking the types.

**TLDR:** updated dep version to remove "loose" versioning that would break types

## Submitter Checklist

Check only those that apply to this change.

- [x] Self-reviewed code, removed extraneous comments, debug logging, checked code style
- [x] No change to users after merge (off-by-default configuration, feature flag, alt URL, etc.) and can be disabled if issues arise (if this is not the case we may need stakeholder signoff)
- [ ] Changes are documented (README, wiki, etc)
- [ ] Automated tests added
- [x] Manually tested changes
- [ ] Metrics added to track the usage/performance
- [x] I am confident I can revert this change
- [ ] Database migrations are reversible without data loss (if applicable)
- [ ] Performance impact is acceptable (if applicable)
- [x] Any new dependencies are justified or have been approved (if applicable)
- [x] **This is NOT a high risk change** (if it is, please follow the high-risk change process)

### Testing Evidence

What evidence supports that you have tested this change?

- [x] Test cases cover the new functionality or changes
- [ ] Screenshots or logs of the changes (if applicable)
- [ ] Performance benchmarks (if applicable)
- [ ] Storybook cases (if applicable)

## Reviewer Checklist

Note: if this PR affects authentication or payments please seek a secondary tester.

- [x] I am ok with code style and functionality
- [ ] I have personally tested the feature
- [ ] My review was not rushed due to time constraints
